### PR TITLE
dashboard setup with theme and upload control

### DIFF
--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -61,13 +61,13 @@ const Header = () => {
             </button>
           </div>
           <nav className={styles.mobileNav}>
-            <Link
+            {/* <Link
               to="/"
               className={styles.mobileMenuItem}
               onClick={toggleMobileMenu}
             >
               Home
-            </Link>
+            </Link> */}
             <Link
               to="/login"
               className={styles.mobileMenuItem}
@@ -89,9 +89,9 @@ const Header = () => {
 
       {/* Desktop Menu */}
       <nav className={styles.desktopMenu}>
-        <Link to="/" className={styles.navItem}>
+        {/* <Link to="/" className={styles.navItem}>
           Home
-        </Link>
+        </Link> */}
         <Link to="/login" className={styles.navItem}>
           Log in
         </Link>

--- a/frontend/src/components/Sidebar/Sidebar.tsx
+++ b/frontend/src/components/Sidebar/Sidebar.tsx
@@ -1,27 +1,41 @@
 import React from 'react';
-import { Link,useLocation } from 'react-router-dom';
 import styles from './sidebar.module.css';
-import logo from "../../assets/courses.png";
+import { useTheme } from '../../containers/Admin/ThemeContext';
 
+const Sidebar: React.FC<{
+    isOpen: boolean,
+    closeSidebar: () => void,
+    activeMenu: 'quiz' | 'settings',
+    setActiveMenu: (menu: 'quiz' | 'settings') => void
+}> = ({ isOpen, closeSidebar, activeMenu, setActiveMenu }) => {
 
+    const { theme } = useTheme();
+    const themeColors = {
+        light: '#7a84f9',
+        dark: '#808080'
+    };
 
-const Sidebar: React.FC = () => {
+    const currentColor = themeColors[theme];
 
-    const currPage = useLocation();
-    
+    const handleMenuClick = (menu: 'quiz' | 'settings') => {
+        setActiveMenu(menu);
+    };
+
     return (
-        <div className={styles.sidebar}>
-            <img src = {logo} alt = "logo"></img>
-            <ul>
-                <li>
-                    <Link to="/">Home</Link>
-                </li>
-                <li>
-                    <Link to="/login">Sign in</Link>
-                </li>
-            </ul>
-        </div>
+        <aside className={`${styles.sidebar} ${isOpen ? styles.open : ''}`} style={{ backgroundColor: currentColor }}>
+            <button className={styles.closeButton} onClick={closeSidebar}>×</button>
+            <nav className={styles.nav}>
+                <ul>
+                    <li className={activeMenu === 'quiz' ? styles.active : ''} onClick={() => handleMenuClick('quiz')}>
+                        <button>Quiz</button>
+                    </li>
+                    <li className={activeMenu === 'settings' ? styles.active : ''} onClick={() => handleMenuClick('settings')}>
+                        <button>Settings</button>
+                    </li>
+                </ul>
+            </nav>
+        </aside>
     );
-}
+};
 
 export default Sidebar;

--- a/frontend/src/components/Sidebar/sidebar.module.css
+++ b/frontend/src/components/Sidebar/sidebar.module.css
@@ -1,34 +1,82 @@
 .sidebar {
-    /* display: flex; */
-    flex-direction: row;
-    width: 200px;
-    height: 100vh; 
-    background-color: #7a84f9; 
-    text-align: center;
-    }
-    
-.sidebar ul {
+    width: 250px;
+    transition: all 0.3s;
+    transform: translateX(-100%);
+    min-height: 100%;
+    position: fixed;
+    top: 0;
+    left: 0;
+    z-index: 1000;
+    padding-top: 30px;
+  }
+  
+  .open {
+    transform: translateX(0);
+  }  
+  
+  .nav {
+    padding: 1rem;
+  }
+  
+  .nav ul {
     list-style: none;
     padding: 0;
-    margin: 0;
-    text-align: center;
-}
-    
-.sidebar ul li {
-    height: auto;
-      
-}
-    
-.sidebar ul li a {
-    display: block;
-    padding: 10px;
+  }
+  
+  .nav li a {
+    color: white;
     text-decoration: none;
+  }
+  
+  @media (max-width: 768px) {
+    .sidebar {
+      width: 200px;
+    }
+  }
+  
+  .closeButton {
+    border: none;
+    font-size: 1.5rem;
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+  }
+
+  .nav li {
+    padding: 0.5rem 0;
+    cursor: pointer;
+  }
+  
+  .nav li.active {
+    border-radius: 20px;
+    border-color: black;
+  }
+  
+  .nav li button {
+    background: none;
+    border: none;
     color: inherit;
-    text-align: center;
-}
-    
-.sidebar ul li a:hover {
-    flex-direction: row;
-    text-align: center;
-    background-color: #ddd;
-}
+    text-align: left;
+    width: 100%;
+    padding: 0.5rem 1rem;
+    cursor: pointer;
+    display: block;
+    transition: background-color 0.3s ease;
+  }
+  
+  .nav li.active button {
+    background-color: #4a4e69;
+    color: #f2e9e4;
+    border-radius: 4px;
+  }
+  
+  .nav li:not(.active) button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  
+  .nav li button:hover {
+    background-color: rgba(255, 255, 255, 0.1);
+  }
+  

--- a/frontend/src/containers/Admin/Quiz.tsx
+++ b/frontend/src/containers/Admin/Quiz.tsx
@@ -4,10 +4,13 @@ import styles from './admin.module.css';
 
 const Quiz = () => {
   const [file, setFile] = useState<File | null>(null);
+  const [fileName, setFileName] = useState<string | null>(null);
   const { upload, loading, error } = useDocumentAPI();
+
   const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const selectedFile = event.target.files ? event.target.files[0] : null;
     setFile(selectedFile);
+    setFileName(selectedFile ? selectedFile.name : null);
   };
 
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
@@ -36,6 +39,7 @@ const Quiz = () => {
           onChange={handleFileChange}
           accept=".pdf, .docx, .txt"
         />
+        {fileName && <p className={styles.selectedFileName}>Selected file: {fileName}</p>}
         <button type="submit" className={styles.quizSubmitButton} disabled={loading}>
           {loading ? 'Uploading...' : 'Upload Quiz'}
         </button>

--- a/frontend/src/containers/Admin/Quiz.tsx
+++ b/frontend/src/containers/Admin/Quiz.tsx
@@ -1,0 +1,48 @@
+import React, { useState } from 'react';
+import { useDocumentAPI } from '../../services/document/context';
+import styles from './admin.module.css';
+
+const Quiz = () => {
+  const [file, setFile] = useState<File | null>(null);
+  const { upload, loading, error } = useDocumentAPI();
+  const handleFileChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const selectedFile = event.target.files ? event.target.files[0] : null;
+    setFile(selectedFile);
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!file) {
+      alert('Please select a file to upload.');
+      return;
+    }
+    
+    upload(file);
+  };
+
+  return (
+    <div className={styles.quizContainer}>
+      <h2 className={styles.quizTitle}>Quiz Area</h2>
+      <p>Welcome to the Quiz room. Start Crafting!</p>
+      <form className={styles.quizForm} onSubmit={handleSubmit}>
+        <label htmlFor="quizFile" className={styles.quizFileInputLabel}>
+          Choose a file
+        </label>
+        <input
+          id="quizFile"
+          type="file"
+          name="quizFile"
+          className={styles.quizFileInput}
+          onChange={handleFileChange}
+          accept=".pdf, .docx, .txt"
+        />
+        <button type="submit" className={styles.quizSubmitButton} disabled={loading}>
+          {loading ? 'Uploading...' : 'Upload Quiz'}
+        </button>
+      </form>
+      {error && <p className={styles.errorText}>Error: {error.message}</p>}
+    </div>
+  );
+};
+
+export default Quiz;

--- a/frontend/src/containers/Admin/Settings.tsx
+++ b/frontend/src/containers/Admin/Settings.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { useTheme } from './ThemeContext';
+
+const Settings = () => {
+  const { toggleTheme } = useTheme();
+
+  return (
+    <div>
+      <h2>Settings</h2>
+      <button onClick={toggleTheme}>Toggle Theme</button>
+      {/* Additional settings can be added here */}
+    </div>
+  );
+};
+
+export default Settings;

--- a/frontend/src/containers/Admin/ThemeContext.tsx
+++ b/frontend/src/containers/Admin/ThemeContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState } from 'react';
+
+// Define a type for the context state
+type ThemeContextType = {
+  theme: 'light' | 'dark';
+  toggleTheme: () => void;
+};
+
+// Create the context with a default value
+const ThemeContext = createContext<ThemeContextType>({ theme: 'light', toggleTheme: () => {} });
+
+// Export the hook to be used in your components
+export const useTheme = () => useContext(ThemeContext);
+
+// Create a provider component
+export const ThemeProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+    const [theme, setTheme] = useState<'light' | 'dark'>('light');
+
+    // Toggle between 'light' and 'dark'
+    const toggleTheme = () => {
+        setTheme((prevTheme) => (prevTheme === 'light' ? 'dark' : 'light'));
+    };
+
+    return (
+        <ThemeContext.Provider value={{ theme, toggleTheme }}>
+            {children}
+        </ThemeContext.Provider>
+    );
+};

--- a/frontend/src/containers/Admin/admin.module.css
+++ b/frontend/src/containers/Admin/admin.module.css
@@ -1,0 +1,132 @@
+/* General Styles */
+:root {
+    --primary-color: #5d93e1;
+    --background-color: #f0f2f5;
+    --text-color: #333;
+    --button-hover-color: #507dbc;
+  }
+  
+  /* Quiz Container */
+  .quizContainer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    padding: 20px;
+    margin: 20px auto;
+    max-width: 600px;
+    background-color: var(--background-color);
+    border-radius: 8px;
+    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+    transition: all 0.3s ease;
+  }
+  
+  /* Quiz Title */
+  .quizTitle {
+    color: var(--text-color);
+    margin-bottom: 20px;
+  }
+  
+  .successText {
+    color: #28a745; /* Bootstrap's success green, or choose your own */
+    margin: 10px 0;
+  }
+  
+
+  /* Quiz Form */
+  .quizForm {
+    width: 100%;
+    display: flex;
+    flex-direction: column;
+  }
+  
+  /* Input Fields */
+  .quizInput {
+    padding: 10px;
+    margin-bottom: 15px;
+    border: 1px solid #ccc;
+    border-radius: 4px;
+  }
+  
+  /* Special styles for file input and its label */
+  .quizFileInput {
+    opacity: 0;
+    position: absolute;
+    width: 0.1px;
+    height: 0.1px;
+    z-index: -1;
+  }
+  
+  .quizFileInputLabel {
+    background-color: var(--primary-color);
+    color: white;
+    padding: 10px 15px;
+    text-align: center;
+    display: inline-block;
+    border-radius: 4px;
+    cursor: pointer;
+    margin-bottom: 15px;
+  }
+  
+  .quizFileInputLabel:hover {
+    background-color: var(--button-hover-color);
+  }
+  
+  /* Submit Button */
+  .quizSubmitButton {
+    padding: 10px 15px;
+    background-color: var(--primary-color);
+    color: white;
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.2s;
+  }
+  
+  .quizSubmitButton:hover {
+    background-color: var(--button-hover-color);
+  }
+  
+  /* Error Text */
+  .errorText {
+    color: #ff6b6b;
+    margin: 10px 0;
+  }
+  
+  /* Responsive Design Adjustments */
+  @media (max-width: 768px) {
+    .quizContainer {
+      margin: 10px;
+      padding: 15px;
+      width: 90%; /* It takes up more of the screen on smaller devices */
+      box-sizing: border-box; /* Include padding in width */
+    }
+  
+    .quizTitle {
+      font-size: 1.25rem; /* Adjust font size for smaller screens */
+    }
+  
+    .quizFileInputLabel,
+    .quizSubmitButton {
+      padding: 8px 12px; /* Adjust padding for smaller screens */
+      font-size: 0.875rem; /* Adjust font size for smaller screens */
+    }
+  }
+  
+  @media (max-width: 480px) {
+    .quizContainer {
+      padding: 10px;
+      margin: 5px;
+      width: 95%; /* Allow even more width on very small screens */
+    }
+  
+    .quizTitle {
+      font-size: 1rem; /* Further adjust font size for very small screens */
+    }
+  
+    .quizFileInputLabel,
+    .quizSubmitButton {
+      padding: 8px 10px; /* Smaller padding for very small screens */
+      font-size: 0.85rem; /* Smaller font size for very small screens */
+    }
+  }
+  

--- a/frontend/src/containers/Admin/admin.module.css
+++ b/frontend/src/containers/Admin/admin.module.css
@@ -1,4 +1,4 @@
-/* General Styles */
+
 :root {
     --primary-color: #5d93e1;
     --background-color: #f0f2f5;
@@ -6,7 +6,6 @@
     --button-hover-color: #507dbc;
   }
   
-  /* Quiz Container */
   .quizContainer {
     display: flex;
     flex-direction: column;
@@ -20,26 +19,22 @@
     transition: all 0.3s ease;
   }
   
-  /* Quiz Title */
   .quizTitle {
     color: var(--text-color);
     margin-bottom: 20px;
   }
   
   .successText {
-    color: #28a745; /* Bootstrap's success green, or choose your own */
+    color: #28a745;
     margin: 10px 0;
   }
   
-
-  /* Quiz Form */
   .quizForm {
     width: 100%;
     display: flex;
     flex-direction: column;
   }
   
-  /* Input Fields */
   .quizInput {
     padding: 10px;
     margin-bottom: 15px;
@@ -47,7 +42,6 @@
     border-radius: 4px;
   }
   
-  /* Special styles for file input and its label */
   .quizFileInput {
     opacity: 0;
     position: absolute;
@@ -71,7 +65,6 @@
     background-color: var(--button-hover-color);
   }
   
-  /* Submit Button */
   .quizSubmitButton {
     padding: 10px 15px;
     background-color: var(--primary-color);
@@ -86,7 +79,6 @@
     background-color: var(--button-hover-color);
   }
   
-  /* Error Text */
   .errorText {
     color: #ff6b6b;
     margin: 10px 0;
@@ -97,18 +89,18 @@
     .quizContainer {
       margin: 10px;
       padding: 15px;
-      width: 90%; /* It takes up more of the screen on smaller devices */
-      box-sizing: border-box; /* Include padding in width */
+      width: 90%;
+      box-sizing: border-box;
     }
   
     .quizTitle {
-      font-size: 1.25rem; /* Adjust font size for smaller screens */
+      font-size: 1.25rem;
     }
   
     .quizFileInputLabel,
     .quizSubmitButton {
-      padding: 8px 12px; /* Adjust padding for smaller screens */
-      font-size: 0.875rem; /* Adjust font size for smaller screens */
+      padding: 8px 12px;
+      font-size: 0.875rem;
     }
   }
   
@@ -116,17 +108,17 @@
     .quizContainer {
       padding: 10px;
       margin: 5px;
-      width: 95%; /* Allow even more width on very small screens */
+      width: 95%;
     }
   
     .quizTitle {
-      font-size: 1rem; /* Further adjust font size for very small screens */
+      font-size: 1rem;
     }
   
     .quizFileInputLabel,
     .quizSubmitButton {
-      padding: 8px 10px; /* Smaller padding for very small screens */
-      font-size: 0.85rem; /* Smaller font size for very small screens */
+      padding: 8px 10px;
+      font-size: 0.85rem;
     }
   }
   

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,7 @@ import { QuizQrafterAuthService } from "./services/auth/quizQrafterAuthService";
 import { DocumentProvider } from "./services/document/context";
 // import { LocalStorageDocumentService } from "./services/document/localStorageDocumentService";
 import { QuizQrafterDocumentService } from "./services/document/quizQrafterDocumentService";
+import { ThemeProvider } from "./containers/Admin/ThemeContext";
 
 const { REACT_APP_API_URL = "http://localhost:8080" } = process.env;
 const apiURL = new URL(REACT_APP_API_URL);
@@ -24,7 +25,9 @@ root.render(
   <React.StrictMode>
     <AuthProvider service={authService}>
       <DocumentProvider service={documentService}>
+      <ThemeProvider>
         <App />
+      </ThemeProvider>
       </DocumentProvider>
     </AuthProvider>
   </React.StrictMode>,

--- a/frontend/src/pages/Dashboard/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard/Dashboard.tsx
@@ -1,23 +1,66 @@
-import React from "react";
-import { useAuth } from "../../services/auth";
-import "./dashboard.module.css";
-import Sidebar from "../../components/Sidebar/Sidebar";
-import sbStyle from "../../components/Sidebar/sidebar.module.css";
+import React, { useState } from 'react';
+import { useAuth } from '../../services/auth';
+import styles from './dashboard.module.css';
+import Sidebar from '../../components/Sidebar/Sidebar';
+import sbStyles from '../../components/Sidebar/sidebar.module.css';
+import Logo from "../../assets/quiz_qrafter_logo_dark.svg";
+import { useTheme } from '../../containers/Admin/ThemeContext';
+import Quiz from '../../containers/Admin/Quiz';
+import Settings from '../../containers/Admin/Settings';
 
 const Dashboard: React.FC = () => {
-  const { signOut } = useAuth();
+  const { user, signOut } = useAuth();
+  const themeColors = {
+    light: '#7a84f9',
+    dark: '#808080'
+  };
+
+  const { theme} = useTheme();
+  const [sidebarOpen, setSidebarOpen] = useState(false);
+  const currentColor = themeColors[theme];
+  const [activeMenu, setActiveMenu] = useState<'quiz' | 'settings'>('quiz');
 
   const handleSignOut = () => {
     signOut();
   };
 
+  const toggleSidebar = () => {
+    setSidebarOpen(!sidebarOpen);
+  };
+
   return (
-    <div>
-      {/* <h1>Dashboard</h1>
-      <button onClick={handleSignOut}>Logout</button> */}
-      <div className = {sbStyle.sidebar}><Sidebar /></div>
-      {/* Add your dashboard content here */}
-    </div>
+    <>
+      <div className={styles.dashboard}>
+        <header className={styles.header} style={{ backgroundColor: currentColor }}>
+          <div className={styles.logoMenu}>
+            <button onClick={toggleSidebar} className={styles.menuButton}>
+              ☰
+            </button>
+
+          </div>
+          <img src={Logo} alt="Quiz Qrafter" className={styles.dashboardLogo} />
+          <div className={styles.headerContent}>
+            {/* <span className={styles.email}>{user?.email}</span> */}
+            <span className={styles.email}>email@gmail.com</span>
+            <button onClick={handleSignOut} className={styles.logoutButton}>
+              LOGOUT
+            </button>
+          </div>
+        </header>
+        <div className={styles.mainContent}>
+          <div className={`${sbStyles.sidebar} ${sidebarOpen ? sbStyles.open : ''}`}>
+            <Sidebar isOpen={sidebarOpen} closeSidebar={toggleSidebar} activeMenu={activeMenu} setActiveMenu={setActiveMenu} />
+          </div>
+          <main className={`${styles.content} ${sidebarOpen ? styles.contentWithSidebar : ''}`}>
+            {activeMenu === 'quiz' ? (
+              <Quiz />
+            ) : (
+              <Settings/>
+            )}
+          </main>
+        </div>
+      </div>
+    </>
   );
 };
 

--- a/frontend/src/pages/Dashboard/dashboard.module.css
+++ b/frontend/src/pages/Dashboard/dashboard.module.css
@@ -1,0 +1,104 @@
+.dashboardLogo {
+    height: auto; 
+    max-width: 100px;
+}
+
+
+.header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    background-color: #2c3e50;
+    color: white;
+    padding: 0.5rem 1rem;
+    position: fixed;
+    width: 100%;
+    top: 0;
+    z-index: 2;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, .1);
+}
+
+.logoMenu, .headerContent {
+    display: flex;
+    align-items: center;
+}
+
+.headerContent {
+    gap: 20px;
+}
+.menuButton {
+    background: none;
+    border: none;
+    color: white;
+    font-size: 24px;
+    cursor: pointer;
+    margin-right: 1rem;
+}
+
+.email {
+    padding-right: none;
+}
+
+.logoutButton {
+    margin: 0 20px;
+    background-color: #ff8c00;
+    color: white;
+    padding: 7px 14px;
+    font-size: 11px;
+    font-weight: bold;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease;
+    letter-spacing: 1px;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+    
+}
+
+.logoutButton:hover,
+.logoutButton:focus {
+    color: #ffffff;
+    background-color: #ff8c00;
+    border-color: #ffffff;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.3);
+}
+
+.logoutButton:active {
+    transform: translateY(1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
+}
+
+
+.mainContent {
+    padding-top: 60px;
+    display: flex;
+    flex-grow: 1;
+}
+
+.content {
+    flex-grow: 1;
+    padding: 1rem;
+    margin-left: 0;
+    transition: margin-left 0.3s;
+}
+
+
+.contentWithSidebar {
+    margin-left: 250px;
+}
+
+@media (max-width: 768px) {
+    .header {
+        padding: 0.5rem;
+    }
+    .logoutButton {
+        margin: 0 10px;
+    }
+    .dashboardLogo {
+        height: 40px;
+    }
+
+    .contentWithSidebar {
+        margin-left: 200px;
+    }
+}


### PR DESCRIPTION
- Added the base setup for the dashboard, ensuring it is responsive for both web and mobile view
- Added ability to set dashboard component theme, which we might need to scale as part of the user settings data information
- Added sidebar menu for the Quiz and Settings menu as well as their individual components rendered when clicking on the menus.
- Hamburger menu to toggle between opened and closed sidebar
- Changed the header to only login and signup. The home link was not necessary for now, we can change it later.

Below are the images:
![image](https://github.com/QuizQrafter/quiz-qrafter/assets/55924606/e7faf229-7821-4a63-bc65-92dd751ac254)
![image](https://github.com/QuizQrafter/quiz-qrafter/assets/55924606/22e81278-ec5f-4df8-abb2-f6f50f01c891)
