### PR TITLE
resolved 404 Not found error upon page refresh

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -1,6 +1,7 @@
 import cors from "cors";
 import "dotenv/config";
 import express from "express";
+import path from 'path';
 
 import v1Router from "./api/v1";
 import prisma from "./database";
@@ -11,10 +12,11 @@ const app = express();
 
 if (process.env.NODE_ENV === 'production') {
   app.set('trust proxy', 1) // trust first proxy
+  app.use(express.static(path.join(__dirname, 'build')));  // Serve static files from the React app's build directory
 }
 
 app.use(express.json());
-app.use(express.urlencoded());
+app.use(express.urlencoded({ extended: true })); // Correctly configure urlencoded to parse URL-encoded bodies
 app.use(
   cors({
     origin: FRONTEND_URL,
@@ -27,6 +29,11 @@ app.get("/healthz", (_req, res) => {
 });
 
 app.use("/api/v1", v1Router);
+
+// Catch-all route to serve React index.html
+app.get('*', (req, res) => {
+  res.sendFile(path.join(__dirname, 'build', 'index.html'));
+});
 
 const server = app.listen(parseInt(PORT), () => {
   console.log(`Live on PORT ${PORT}`);


### PR DESCRIPTION
## Problem:
There was a `404 Not Found` error when refreshing pages or directly accessing routes in the deployed production app.

## Solution:
Updated the server configuration to support client-side routing by serving the index.html file for all routes not covered by the API.

These should fix the handling of the `404 error not found` upon page refresh by making sure React Router can handle routing post-page load.

![image](https://github.com/QuizQrafter/quiz-qrafter/assets/55924606/e4f908c6-6e8d-4c84-9d7d-113ae39a89ee)
